### PR TITLE
cluster: remove member from ring on failure

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -217,7 +217,7 @@ func (c *Cluster) handleSerfEvent(e serf.Event) {
 
 	case serf.EventMemberFailed:
 		c.logger.Debug("Handling unresponsive member event")
-		go c.updateEventMembers(e)
+		go c.removeEventMembers(e)
 
 	case serf.EventMemberUpdate:
 		c.logger.Debug("Handling member metadata update event")


### PR DESCRIPTION
Without this change unresponsive nodes retain ownership of their partitions.
